### PR TITLE
fetch 250 prices from coingecko

### DIFF
--- a/external_services/coingecko_service.go
+++ b/external_services/coingecko_service.go
@@ -64,7 +64,7 @@ func NewCoingeckoRequest() string {
 		}
 	}
 	url = strings.TrimSuffix(url, ",")
-	url += "&order=market_cap_desc&price_change_percentage=24h&sparkline=true"
+	url += "&order=market_cap_desc&price_change_percentage=24h&sparkline=true&per_page=250"
 	return url
 }
 


### PR DESCRIPTION
realized that we have only ~230 geckoids, so this will fix https://github.com/KomodoPlatform/mm2-client/issues/2 till we have more then 250 ids, then we need the page=x param like in nomics